### PR TITLE
Improve configuration reload and logging robustness

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -58,10 +58,17 @@ class Config:
 
         if config_path:
             config.update(_load_yaml(Path(config_path)))
+            # Persist the path so interfaces (API/WebUI) can reload the same
+            # configuration when applying a different preset later on.
+            config["config_path"] = str(config_path)
 
         if overrides:
             for key, value in overrides.items():
                 _set_deep(config, key, value)
+
+        if preset:
+            # Record the preset used so it can be referenced or reloaded.
+            config["preset"] = preset
 
         return cls(config)
 

--- a/core/fingerprint.py
+++ b/core/fingerprint.py
@@ -22,7 +22,9 @@ def fingerprint_url(url: str) -> Set[str]:
     try:
         response = requests.get(url, timeout=10)
     except requests.RequestException as exc:  # pragma: no cover - network errors
-        log.debug(f"fingerprint failed for %s: %s", url, exc)
+        # Avoid mixing f-strings with percent formatting which caused the
+        # literal ``%s`` tokens to appear in logs instead of the values.
+        log.debug("fingerprint failed for %s: %s", url, exc)
         return set()
 
     hints: Set[str] = set()

--- a/core/logger.py
+++ b/core/logger.py
@@ -55,7 +55,10 @@ def get_logger(
     old_emit = console_handler.emit
 
     def emit(record):
-        record.msg = _colorize(record.levelname, record.msg)
+        # ``record.msg`` may not always be a string (e.g. logging objects), so
+        # ensure it is converted before applying ANSI colour codes to avoid
+        # ``TypeError`` exceptions during logging.
+        record.msg = _colorize(record.levelname, str(record.msg))
         old_emit(record)
 
     console_handler.emit = emit  # type: ignore

--- a/payloads/builder.py
+++ b/payloads/builder.py
@@ -75,8 +75,10 @@ class PayloadBuilder:
         payload_code: Optional[str] = None,
         obfuscate: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        *,
+        return_meta: bool = False,
         **variables: Any,
-    ) -> str:
+    ) -> str | tuple[str, Dict[str, Any]]:
         """Render ``template`` with metadata and optional payload."""
         meta = metadata.copy() if metadata else {}
         profile = self._random_profile()
@@ -89,7 +91,8 @@ class PayloadBuilder:
         meta.update(variables)
         tmpl = self.env.get_template(template)
         self.log.debug("Rendering template %s with %s", template, meta)
-        return tmpl.render(**meta)
+        rendered = tmpl.render(**meta)
+        return (rendered, meta) if return_meta else rendered
 
     def build(
         self,
@@ -103,11 +106,12 @@ class PayloadBuilder:
         **variables: Any,
     ) -> RenderedPayload:
         """Render template, optionally write to ``output_dir`` and return info."""
-        content = self.render(
+        content, meta = self.render(
             template,
             payload_code=payload_code,
             obfuscate=obfuscate,
             metadata=metadata,
+            return_meta=True,
             **variables,
         )
         path: Optional[Path] = None
@@ -127,4 +131,4 @@ class PayloadBuilder:
                 atomic_write(tmp_path, content)
                 self.log.debug("Wrote ephemeral payload to %s", tmp_path)
                 cleanup(tmp_path)
-        return RenderedPayload(content=content, path=path, metadata=metadata or {})
+        return RenderedPayload(content=content, path=path, metadata=meta)


### PR DESCRIPTION
## Summary
- ensure configuration reload preserves path and preset
- harden logging and error collection
- expose payload metadata when building templates

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a4361350832a9af205bfc93d7e1b